### PR TITLE
Simplify dataset loader config

### DIFF
--- a/llm-foundry-finetune/configs/finetune_mpt7b.yaml
+++ b/llm-foundry-finetune/configs/finetune_mpt7b.yaml
@@ -32,13 +32,11 @@ tokenizer:
 train_loader:
   name: finetuning
   dataset:
-    hf_name: databricks/databricks-dolly-15k
-    split: train[:90%]
-    prompt_col: instruction
-    response_col: response
+    name: jsonl                 # load local JSONL
+    input_path: data/dolly_15k_txt/train.jsonl
     decoder_only_format: true
     shuffle: true
-    max_seq_len: 1024
+    max_seq_len: ${max_seq_len}
   drop_last: false
   device_batch_size: 1
   num_workers: 2
@@ -50,13 +48,11 @@ train_loader:
 eval_loader:
   name: finetuning
   dataset:
-    hf_name: databricks/databricks-dolly-15k
-    split: train[90%:]
-    prompt_col: instruction
-    response_col: response
+    name: jsonl
+    input_path: data/dolly_15k_txt/validation.jsonl
     decoder_only_format: true
     shuffle: false
-    max_seq_len: 1024
+    max_seq_len: ${max_seq_len}
   drop_last: false
   device_batch_size: 1
   num_workers: 2
@@ -100,7 +96,7 @@ callbacks:
   hf_checkpointer:
     save_folder: ./checkpoints              # where to write HF-format checkpoints
     save_interval: 1ep                      # every epoch
-    huggingface_folder_name: ba{batch}      # sub-folder format
+    huggingface_folder_name: "ba{batch}"      # sub-folder format
     precision: float16
     overwrite: true
     mlflow_registered_model_name: null      # no MLflow registry

--- a/llm-foundry-finetune/configs/finetune_mpt7b.yaml
+++ b/llm-foundry-finetune/configs/finetune_mpt7b.yaml
@@ -9,7 +9,6 @@ variables:
 
 device_train_microbatch_size: 1
 global_train_batch_size: 8
-max_seq_len: 1024
 precision: bf16
 
 # ---- model ----
@@ -36,7 +35,7 @@ train_loader:
     input_path: data/dolly_15k_txt/train.jsonl
     decoder_only_format: true
     shuffle: true
-    max_seq_len: ${max_seq_len}
+    max_seq_len: 1024
   drop_last: false
   device_batch_size: 1
   num_workers: 2
@@ -52,7 +51,7 @@ eval_loader:
     input_path: data/dolly_15k_txt/validation.jsonl
     decoder_only_format: true
     shuffle: false
-    max_seq_len: ${max_seq_len}
+    max_seq_len: 1024
   drop_last: false
   device_batch_size: 1
   num_workers: 2


### PR DESCRIPTION
## Summary
- remove prompt/response column settings from dataset blocks
- keep HF checkpointer sub-folder quoted

## Testing
- `pytest -q` *(no tests ran)*


------
https://chatgpt.com/codex/tasks/task_e_68479d8741e48332bb00d11c19a5f305