### PR TITLE
Fix missing max_seq_len in training config

### DIFF
--- a/llm-foundry-finetune/configs/finetune_mpt7b.yaml
+++ b/llm-foundry-finetune/configs/finetune_mpt7b.yaml
@@ -10,6 +10,7 @@ variables:
 device_train_microbatch_size: 1
 global_train_batch_size: 8
 precision: bf16
+max_seq_len: 1024
 
 # ---- model ----
 model:


### PR DESCRIPTION
## Summary
- specify `max_seq_len` in `finetune_mpt7b.yaml` so `TrainConfig` can load successfully

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b4c96dec8332951c64803d50767a