### PR TITLE
Fix dataset split key

### DIFF
--- a/llm-foundry-finetune/configs/finetune_mpt7b.yaml
+++ b/llm-foundry-finetune/configs/finetune_mpt7b.yaml
@@ -33,7 +33,7 @@ train_loader:
   name: finetuning
   dataset:
     hf_name: json
-    hf_split: train
+    split: train
     data_files: data/dolly_15k_txt/train.jsonl
     decoder_only_format: true
     shuffle: true
@@ -50,7 +50,7 @@ eval_loader:
   name: finetuning
   dataset:
     hf_name: json
-    hf_split: validation
+    split: validation
     data_files: data/dolly_15k_txt/validation.jsonl
     decoder_only_format: true
     shuffle: false


### PR DESCRIPTION
## Summary
- update `finetune_mpt7b.yaml` to use the correct `split` key instead of `hf_split`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847c0c417088332ba9017ee38654259