### PR TITLE
Fix dataset paths for HF json loader

### DIFF
--- a/llm-foundry-finetune/configs/finetune_mpt7b.yaml
+++ b/llm-foundry-finetune/configs/finetune_mpt7b.yaml
@@ -34,7 +34,10 @@ train_loader:
   dataset:
     hf_name: json
     split: train
-    data_files: data/dolly_15k_txt/train.jsonl
+    # HF `json` dataset expects split files to be provided in a dictionary.
+    # Point to the JSONL file inside the corresponding split directory.
+    data_files:
+      train: data/dolly_15k_txt/train/train.jsonl
     decoder_only_format: true
     shuffle: true
     max_seq_len: 1024
@@ -51,7 +54,8 @@ eval_loader:
   dataset:
     hf_name: json
     split: validation
-    data_files: data/dolly_15k_txt/validation.jsonl
+    data_files:
+      validation: data/dolly_15k_txt/validation/validation.jsonl
     decoder_only_format: true
     shuffle: false
     max_seq_len: 1024


### PR DESCRIPTION
## Summary
- fix dataset paths in training config to use split-specific files

## Testing
- `python llm-foundry-finetune/prepare_dolly.py` *(fails: ModuleNotFoundError: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_e_6847ca0b28cc833292a4d06b1a773618